### PR TITLE
Replace '.replaceWith' with '.html'

### DIFF
--- a/js/jquery.tempgauge.js
+++ b/js/jquery.tempgauge.js
@@ -22,7 +22,7 @@
 			canvas.width = opts.width;
 			canvas.height = opts.width * 2 + opts.labelSize;
 			
-			$(gauge).replaceWith(canvas);
+			$(gauge).html(canvas);
 			
 			var percentage = calculatePercentage(currentTemp, opts.minTemp, opts.maxTemp - opts.minTemp);
 


### PR DESCRIPTION
For my use case I wanted to dynamically and regularly update the temperature gauge with a new value without having to reload the page.  Using '.replaceWith' wiped out the <div id=> tag and so subsequent calls to update the div text were unsuccessful.  Using '.html' instead maintains the div tag and therefore the temp gauge can update as desired